### PR TITLE
Add view to return file data JSON object

### DIFF
--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -194,6 +195,17 @@ func FileDownload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := fd.ServeData(w, r, fd.Mimetype, fd.GetFilename(), true); err != nil {
+		utils.Error(w, err)
+	}
+}
+
+func FileJSON(w http.ResponseWriter, r *http.Request) {
+	fd := getFile(w, r)
+	if fd == nil {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if err := json.NewEncoder(w).Encode(fd); err != nil {
 		utils.Error(w, err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 	r.HandleFunc("/", views.Index)
 	r.HandleFunc("/robots.txt", views.Robots)
 	r.HandleFunc("/list", views.List)
+	r.HandleFunc("/{id}.json", views.FileJSON)
 	r.HandleFunc("/{id}.txt", views.FileText)
 	r.HandleFunc("/{id}/download", views.FileDownload)
 	r.HandleFunc("/{id}", views.Delete).Methods("DELETE")


### PR DESCRIPTION
This adds a simples view to return the file data JSON object when suffixing `.json`  to the URL, similar to the current `.txt` view.